### PR TITLE
added clang-format-7

### DIFF
--- a/FindClangFormat.cmake
+++ b/FindClangFormat.cmake
@@ -31,7 +31,8 @@
 #    endif()
 
 find_program(CLANG_FORMAT_EXECUTABLE
-  NAMES clang-format clang-format-5.0
+  NAMES clang-format clang-format-7
+        clang-format-6.0 clang-format-5.0
         clang-format-4.0 clang-format-3.9
         clang-format-3.8 clang-format-3.7
         clang-format-3.6 clang-format-3.5


### PR DESCRIPTION
Not entirely sure about version 6.0 but at least in version 7 the binary name seems to have dropped the minor version number